### PR TITLE
FactGenerator: Rename `isvolatile` to `is_volatile`

### DIFF
--- a/FactGenerator/include/predicates.inc
+++ b/FactGenerator/include/predicates.inc
@@ -297,8 +297,7 @@ PREDICATE2(load, instr)
 PREDICATEI(load, alignment)
 PREDICATEI(load, ordering)
 PREDICATEI(load, address)
-// TODO(#42):
-PREDICATE(load, isvolatile, load_instr_is_volatile)
+PREDICATEI(load, is_volatile)
 GROUP_END(load)
 
 GROUP_BEGIN(store)
@@ -307,8 +306,7 @@ PREDICATEI(store, alignment)
 PREDICATEI(store, ordering)
 PREDICATEI(store, value)
 PREDICATEI(store, address)
-// TODO(#42):
-PREDICATE(store, isvolatile, store_instr_is_volatile)
+PREDICATEI(store, is_volatile)
 GROUP_END(store)
 
 GROUP_BEGIN(fence)
@@ -322,8 +320,7 @@ PREDICATEI(atomicrmw, ordering)
 PREDICATEI(atomicrmw, operation)
 PREDICATEI(atomicrmw, address)
 PREDICATEI(atomicrmw, value)
-// TODO(#42):
-PREDICATE(atomicrmw, isvolatile, atomicrmw_instr_is_volatile)
+PREDICATEI(atomicrmw, is_volatile)
 GROUP_END(atomicrmw)
 
 GROUP_BEGIN(cmpxchg)
@@ -333,8 +330,7 @@ PREDICATEI(cmpxchg, address)
 PREDICATEI(cmpxchg, cmp_value)
 PREDICATEI(cmpxchg, new_value)
 PREDICATEI(cmpxchg, type)
-// TODO(#42):
-PREDICATE(cmpxchg, isvolatile, cmpxchg_instr_is_volatile)
+PREDICATEI(cmpxchg, is_volatile)
 GROUP_END(cmpxchg)
 
 GROUP_BEGIN(gep)

--- a/FactGenerator/src/InstructionVisitor.cpp
+++ b/FactGenerator/src/InstructionVisitor.cpp
@@ -346,7 +346,7 @@ void InstructionVisitor::visitLoadInst(const llvm::LoadInst &LI) {
   if (LI.getAlignment())
     gen.writeFact(pred::load::alignment, iref, LI.getAlignment());
 
-  if (LI.isVolatile()) gen.writeFact(pred::load::isvolatile, iref);
+  if (LI.isVolatile()) gen.writeFact(pred::load::is_volatile, iref);
 }
 
 void InstructionVisitor::visitVAArgInst(const llvm::VAArgInst &VI) {
@@ -385,7 +385,7 @@ void InstructionVisitor::visitStoreInst(const llvm::StoreInst &SI) {
   if (SI.getAlignment())
     gen.writeFact(pred::store::alignment, iref, SI.getAlignment());
 
-  if (SI.isVolatile()) gen.writeFact(pred::store::isvolatile, iref);
+  if (SI.isVolatile()) gen.writeFact(pred::store::is_volatile, iref);
 }
 
 void InstructionVisitor::visitAtomicCmpXchgInst(
@@ -396,7 +396,7 @@ void InstructionVisitor::visitAtomicCmpXchgInst(
   writeInstrOperand(pred::cmpxchg::cmp_value, iref, AXI.getCompareOperand());
   writeInstrOperand(pred::cmpxchg::new_value, iref, AXI.getNewValOperand());
 
-  if (AXI.isVolatile()) gen.writeFact(pred::cmpxchg::isvolatile, iref);
+  if (AXI.isVolatile()) gen.writeFact(pred::cmpxchg::is_volatile, iref);
 
   llvm::AtomicOrdering successOrd = AXI.getSuccessOrdering();
   llvm::AtomicOrdering failureOrd = AXI.getFailureOrdering();
@@ -428,7 +428,7 @@ void InstructionVisitor::visitAtomicRMWInst(const llvm::AtomicRMWInst &AWI) {
   writeInstrOperand(pred::atomicrmw::address, iref, AWI.getPointerOperand());
   writeInstrOperand(pred::atomicrmw::value, iref, AWI.getValOperand());
 
-  if (AWI.isVolatile()) gen.writeFact(pred::atomicrmw::isvolatile, iref);
+  if (AWI.isVolatile()) gen.writeFact(pred::atomicrmw::is_volatile, iref);
 
   writeAtomicRMWOp(iref, AWI.getOperation());
   writeAtomicInfo<pred::atomicrmw>(iref, AWI);


### PR DESCRIPTION
This matches the naming scheme in the Datalog code.