### PR TITLE
Remove subset-and-unification target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,6 @@ add_subdirectory(datalog)
 # upgraded.
 set(SOUFFLE_FLAGS -jauto -PSIPS:max-bound
                   --disable-transformers=ExpandEqrelsTransformer)
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/subset-and-unification.cpp
-  COMMAND
-    ${SOUFFLE_BIN}
-    ${CMAKE_CURRENT_LIST_DIR}/datalog/subset-and-unification.project
-    ${SOUFFLE_FLAGS} -g ${CMAKE_CURRENT_BINARY_DIR}/subset-and-unification.cpp
-  DEPENDS ${DL_SOURCES})
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/subset.cpp
@@ -64,7 +57,6 @@ add_custom_command(
 add_library(
   SoufflePAObject OBJECT
   ${CMAKE_CURRENT_BINARY_DIR}/debug.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/subset-and-unification.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/subset.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/unification.cpp)
 

--- a/doc/implementation.rst
+++ b/doc/implementation.rst
@@ -286,9 +286,6 @@ a single translation unit. cclyzer++ has several top-level "project files" that
   of the relations.
 - ``subset.project`` includes only the files necessary to run the subset
   analysis and export the core points-to relations.
-- ``subset-and-unification.project`` includes only the files necessary to run
-  the both the subset and unification analyses and export the core points-to
-  relations for both.
 - ``unification.project`` includes only the files necessary to run the
   unification analysis and export the core points-to relations.
 

--- a/src/PointerAnalysis.cpp
+++ b/src/PointerAnalysis.cpp
@@ -22,7 +22,6 @@ namespace fs = boost::filesystem;
 
 enum class Analysis {
   DEBUG,
-  SUBSET_AND_UNIFICATION,
   SUBSET,
   UNIFICATION,
 };
@@ -33,8 +32,6 @@ llvm::cl::opt<Analysis> datalog_analysis(
     llvm::cl::desc("Which pointer analysis to variant run"),
     llvm::cl::values(
         clEnumValN(Analysis::DEBUG, "debug", "debug (both)"),
-        clEnumValN(
-            Analysis::SUBSET_AND_UNIFICATION, "subset-and-unification", "both"),
         clEnumValN(Analysis::SUBSET, "subset", "subset analysis only"),
         clEnumValN(
             Analysis::UNIFICATION,
@@ -120,8 +117,6 @@ static auto get_interface(Analysis which) -> std::unique_ptr<PAInterface> {
   switch (which) {
     case Analysis::DEBUG:
       return PAInterface::create("debug");
-    case Analysis::SUBSET_AND_UNIFICATION:
-      return PAInterface::create("subset_and_unification");
     case Analysis::SUBSET:
       return PAInterface::create("subset");
     case Analysis::UNIFICATION:
@@ -133,8 +128,6 @@ static auto get_interface(Analysis which) -> std::unique_ptr<PAInterface> {
 static auto callgraph_edge(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
-      [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
       [[fallthrough]];
     case Analysis::SUBSET:
       return "subset.callgraph.callgraph_edge";
@@ -148,8 +141,6 @@ static auto alloc_may_alias(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
       [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
-      [[fallthrough]];
     case Analysis::SUBSET:
       return "subset_lift.alloc_may_alias_ctx";
     case Analysis::UNIFICATION:
@@ -161,8 +152,6 @@ static auto alloc_may_alias(Analysis which) -> std::string {
 static auto alloc_must_alias(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
-      [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
       [[fallthrough]];
     case Analysis::SUBSET:
       return "subset_lift.alloc_must_alias_ctx";
@@ -176,8 +165,6 @@ static auto alloc_subregion(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
       [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
-      [[fallthrough]];
     case Analysis::SUBSET:
       return "subset_lift.alloc_subregion_ctx";
     case Analysis::UNIFICATION:
@@ -189,8 +176,6 @@ static auto alloc_subregion(Analysis which) -> std::string {
 static auto alloc_contains(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
-      [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
       [[fallthrough]];
     case Analysis::SUBSET:
       return "subset_lift.alloc_contains_ctx";
@@ -204,8 +189,6 @@ static auto ptr_points_to(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
       [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
-      [[fallthrough]];
     case Analysis::SUBSET:
       return "subset.ptr_points_to";
     case Analysis::UNIFICATION:
@@ -217,8 +200,6 @@ static auto ptr_points_to(Analysis which) -> std::string {
 static auto operand_points_to(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
-      [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
       [[fallthrough]];
     case Analysis::SUBSET:
       return "subset.operand_points_to";
@@ -232,8 +213,6 @@ static auto var_points_to(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
       [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
-      [[fallthrough]];
     case Analysis::SUBSET:
       return "subset.var_points_to";
     case Analysis::UNIFICATION:
@@ -246,8 +225,6 @@ static auto allocation_size(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
       [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
-      [[fallthrough]];
     case Analysis::SUBSET:
       return "subset_lift.allocation_size_ctx";
     case Analysis::UNIFICATION:
@@ -259,8 +236,6 @@ static auto allocation_size(Analysis which) -> std::string {
 static auto allocation_by_instr(Analysis which) -> std::string {
   switch (which) {
     case Analysis::DEBUG:
-      [[fallthrough]];
-    case Analysis::SUBSET_AND_UNIFICATION:
       [[fallthrough]];
     case Analysis::SUBSET:
       return "subset_lift.allocation_by_instr_ctx";

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,7 +17,6 @@ import pytest
 @unique
 class PointerAnalysis(str, Enum):
     DEBUG = "debug"
-    SUBSET_AND_UNIFICATION = "subset-and-unification"
     SUBSET = "subset"
     UNIFICATION = "unification"
 


### PR DESCRIPTION
There was some idea that this could be a useful mode of analysis, but it wasn't executed to a point where it's actually usable. The generated C++ file is huge and takes a long time to compile, so let's avoid it.

The "debug" build still includes both analyses, ensuring compatibility (e.g., that they don't define relations with the same name).