### PR TITLE
datalog: Turn `Instruction` into a union of instruction types

### DIFF
--- a/datalog/points-to/allocations-decl.dl
+++ b/datalog/points-to/allocations-decl.dl
@@ -35,8 +35,8 @@ basic_allocation(?alloc) :-
 .decl stack_allocation_by_type_instr(?type:Type, ?insn:AllocaInstruction, ?stackAlloc:StackAllocation)
 .decl stack_allocation_by_parameter(?func:FunctionDecl, ?index:number, ?stackAlloc:StackAllocation)
 
-.decl heap_allocation_by_instr(?insn:CallInstruction, ?heapAlloc:HeapAllocation)
-.decl heap_allocation_by_type_instr(?type:Type, ?insn:CallInstruction, ?heapAlloc:HeapAllocation)
+.decl heap_allocation_by_instr(?insn:CallBase, ?heapAlloc:HeapAllocation)
+.decl heap_allocation_by_type_instr(?type:Type, ?insn:CallBase, ?heapAlloc:HeapAllocation)
 
 .decl global_allocation_by_func(?func:FunctionDecl, ?globalAlloc:GlobalAllocation)
 .decl global_allocation_by_variable(?var:GlobalVariable, ?globalAlloc:GlobalAllocation)
@@ -58,7 +58,7 @@ heap_alloc_func(?func) :-
 // it isn't used to compute any further results, just in lift.dl.
 //
 // See subset-rules.dl and unification-rules.dl.
-.type AllocInstruction = CallInstruction | AllocaInstruction
+.type AllocInstruction = CallBase | AllocaInstruction
 .decl allocation_by_instr(?insn:AllocInstruction, ?alloc:Allocation)
 
 allocation_by_instr(?insn, ?alloc) :-

--- a/datalog/points-to/cplusplus-exceptions.dl
+++ b/datalog/points-to/cplusplus-exceptions.dl
@@ -53,7 +53,7 @@ sized_alloc_instr(?insn, as(?size, Bytes)) :-
   // https://souffle-lang.github.io/components#input-rules
   //----------------------------------------------------------------------------
 
-  .decl heap_allocation_by_type_instr(?type: Type, ?insn: Instruction, ?heapAlloc: HeapAllocation) inline
+  .decl heap_allocation_by_type_instr(?type: Type, ?insn: CallBase, ?heapAlloc: HeapAllocation) inline
 
   //----------------------------------------------------------------------------
   // "Output"/defined rules

--- a/datalog/points-to/interprocedural.dl
+++ b/datalog/points-to/interprocedural.dl
@@ -103,7 +103,7 @@ func_by_location(?alloc, ?callee) :-
 
   _callgraph_edge_interim_direct_invoke(?callee, ?callerCtx, ?callerInstr)
    :-
-     direct_call_instr(?callerInstr),
+     direct_invoke_instr(?callerInstr),
      invoke_instr_fn_target(?callerInstr, ?callee),
      instr_func(?callerInstr, ?instrFunc),
      reachable_context(?callerCtx, ?instrFunc).

--- a/datalog/points-to/type-back-propagation.dl
+++ b/datalog/points-to/type-back-propagation.dl
@@ -72,7 +72,7 @@
      baseSize != 0, // TODO: Does anything else need to be done in this case?
      size = (size / baseSize) * baseSize.
 
-  .decl heap_allocation_by_type_instr(?type: Type, ?insn: Instruction, ?heapAlloc: HeapAllocation)
+  .decl heap_allocation_by_type_instr(?type: Type, ?insn: CallBase, ?heapAlloc: HeapAllocation)
   .decl assign_rebase_alloc(?typedAlloc: Allocation, ?aCtx: Context, ?alloc: Allocation, ?var: Variable)
 
   heap_allocation_by_type_instr(?type, ?allocInstr, ?typedAlloc),
@@ -137,7 +137,7 @@
   // where the underlying alloca has an integer-type, but we might want to
   // change this if we see other examples in the wild.
 
-  .decl stack_allocation_by_type_instr(?type: Type, ?insn: Instruction, ?stackAlloc: StackAllocation)
+  .decl stack_allocation_by_type_instr(?type: Type, ?insn: AllocaInstruction, ?stackAlloc: StackAllocation)
   .decl stack_type_indication(?type: Type, ?aCtx: Context, ?alloc: Allocation)
 
   stack_type_indication(?type, ?aCtx, ?alloc) :-

--- a/datalog/schema/add-instr.dl
+++ b/datalog/schema/add-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#add-instr
 // keywords: arithmetic; binary; instr
 
-.type AddInstruction = Instruction
+.type AddInstruction <: symbol
 .decl add_instr(instr:AddInstruction)
 
 instr(v) :-

--- a/datalog/schema/alloca-instr.dl
+++ b/datalog/schema/alloca-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#alloca-instr
 // keywords: memory; unary; instr
 
-.type AllocaInstruction = Instruction
+.type AllocaInstruction <: symbol
 .decl alloca_instr(instr:AllocaInstruction)
 
 instr(v) :- alloca_instr(v).

--- a/datalog/schema/and-instr.dl
+++ b/datalog/schema/and-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#and-instr
 // keywords: bitwise; binary; instr
 
-.type AndInstruction = Instruction
+.type AndInstruction <: symbol
 .decl and_instr(instr:AndInstruction)
 
 instr(v) :-

--- a/datalog/schema/ashr-instr.dl
+++ b/datalog/schema/ashr-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#ashr-instr
 // keywords: bitwise; binary; instr
 
-.type AShrInstruction = Instruction
+.type AShrInstruction <: symbol
 .decl ashr_instr(instr:AShrInstruction)
 
 instr(v) :-

--- a/datalog/schema/atomicrmw-instr.dl
+++ b/datalog/schema/atomicrmw-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#atomicrmw-instr
 // keywords: memory; instr
 
-.type AtomicRMWInstruction = Instruction
+.type AtomicRMWInstruction <: symbol
 .decl atomicrmw_instr(instr:AtomicRMWInstruction)
 
 instr(v) :- atomicrmw_instr(v).

--- a/datalog/schema/bitcast-instr.dl
+++ b/datalog/schema/bitcast-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#bitcast-to-instr
 // keywords: conversion; unary; instr
 
-.type BitcastInstruction = Instruction
+.type BitcastInstruction <: symbol
 .decl bitcast_instr(instr:BitcastInstruction)
 
 instr(v) :- bitcast_instr(v).

--- a/datalog/schema/br-instr.dl
+++ b/datalog/schema/br-instr.dl
@@ -1,9 +1,12 @@
 // http://llvm.org/docs/LangRef.html#br-instr
 // keywords: terminator; instr
 
-.type BrInstruction = Instruction
-.type BrCondInstruction = BrInstruction
-.type BrUncondInstruction = BrInstruction
+.type BrInstruction
+  = BrCondInstruction
+  | BrUncondInstruction
+
+.type BrCondInstruction <: symbol
+.type BrUncondInstruction <: symbol
 
 .decl br_instr(instr:BrInstruction)
 .decl br_instr_cond(instr:BrCondInstruction)

--- a/datalog/schema/call-instr.dl
+++ b/datalog/schema/call-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#call-instr
 // keywords: instr
 
-.type CallInstruction = Instruction
+.type CallInstruction <: symbol
 .decl call_instr(instr:CallInstruction)
 
 instr(v) :- call_instr(v).

--- a/datalog/schema/cmpxchg-instr.dl
+++ b/datalog/schema/cmpxchg-instr.dl
@@ -10,7 +10,7 @@
 //    ; yields  { ty, i1 }
 //
 
-.type CmpXchgInstruction = Instruction
+.type CmpXchgInstruction <: symbol
 .decl cmpxchg_instr(instr:CmpXchgInstruction)
 
 instr(v) :- cmpxchg_instr(v).

--- a/datalog/schema/extractelement-instr.dl
+++ b/datalog/schema/extractelement-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#extractelement-instr
 // keywords: vector; instr
 
-.type ExtractElementInstruction = Instruction
+.type ExtractElementInstruction <: symbol
 .decl extractelement_instr(instr:ExtractElementInstruction)
 
 instr(v) :- extractelement_instr(v).

--- a/datalog/schema/extractvalue-instr.dl
+++ b/datalog/schema/extractvalue-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#extractvalue-instr
 // keywords: aggregate; instr
 
-.type ExtractValueInstruction = Instruction
+.type ExtractValueInstruction <: symbol
 .decl extractvalue_instr(instr:ExtractValueInstruction)
 
 instr(v) :- extractvalue_instr(v).

--- a/datalog/schema/fadd-instr.dl
+++ b/datalog/schema/fadd-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fadd-instr
 // keywords: arithmetic; binary; instr
 
-.type FAddInstruction = Instruction
+.type FAddInstruction <: symbol
 .decl fadd_instr(instr:FAddInstruction)
 
 instr(v) :- fadd_instr(v).

--- a/datalog/schema/fcmp-instr.dl
+++ b/datalog/schema/fcmp-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fcmp-instr
 // keywords: comparison; binary; instr
 
-.type FCmpInstruction = Instruction
+.type FCmpInstruction <: symbol
 .decl fcmp_instr(instr:FCmpInstruction)
 
 instr(v) :- fcmp_instr(v).

--- a/datalog/schema/fdiv-instr.dl
+++ b/datalog/schema/fdiv-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fdiv-instr
 // keywords: arithmetic; binary; instr
 
-.type FDivInstruction = Instruction
+.type FDivInstruction <: symbol
 .decl fdiv_instr(instr:FDivInstruction)
 
 instr(v) :- fdiv_instr(v).

--- a/datalog/schema/fence-instr.dl
+++ b/datalog/schema/fence-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fence-instr
 // keywords: memory; instr
 
-.type FenceInstruction = Instruction
+.type FenceInstruction <: symbol
 .decl fence_instr(instr:FenceInstruction)
 
 instr(v) :- fence_instr(v).

--- a/datalog/schema/fmul-instr.dl
+++ b/datalog/schema/fmul-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fmul-instr
 // keywords: arithmetic; binary; instr
 
-.type FMulInstruction = Instruction
+.type FMulInstruction <: symbol
 .decl fmul_instr(instr:FMulInstruction)
 
 instr(v) :- fmul_instr(v).

--- a/datalog/schema/fpext-instr.dl
+++ b/datalog/schema/fpext-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fpext-to-instr
 // keywords: conversion; unary; instr
 
-.type FPExtInstruction = Instruction
+.type FPExtInstruction <: symbol
 .decl fpext_instr(instr:FPExtInstruction)
 
 instr(v) :- fpext_instr(v).

--- a/datalog/schema/fptosi-instr.dl
+++ b/datalog/schema/fptosi-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fptosi-to-instr
 // keywords: conversion; unary; instr
 
-.type FPToSIInstruction = Instruction
+.type FPToSIInstruction <: symbol
 .decl fptosi_instr(instr:FPToSIInstruction)
 
 instr(v) :- fptosi_instr(v).

--- a/datalog/schema/fptoui-instr.dl
+++ b/datalog/schema/fptoui-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fptoui-to-instr
 // keywords: conversion; unary; instr
 
-.type FPToUIInstruction = Instruction
+.type FPToUIInstruction <: symbol
 .decl fptoui_instr(instr:FPToUIInstruction)
 
 instr(v) :- fptoui_instr(v).

--- a/datalog/schema/fptrunc-instr.dl
+++ b/datalog/schema/fptrunc-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#trunc-to-instr
 // keywords: conversion; unary; instr
 
-.type FPTruncInstruction = Instruction
+.type FPTruncInstruction <: symbol
 .decl fptrunc_instr(instr:FPTruncInstruction)
 
 instr(v) :- fptrunc_instr(v).

--- a/datalog/schema/frem-instr.dl
+++ b/datalog/schema/frem-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#frem-instr
 // keywords: arithmetic; binary; instr
 
-.type FRemInstruction = Instruction
+.type FRemInstruction <: symbol
 .decl frem_instr(instr:FRemInstruction)
 
 instr(v) :- frem_instr(v).

--- a/datalog/schema/fsub-instr.dl
+++ b/datalog/schema/fsub-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#fsub-instr
 // keywords: arithmetic; binary; instr
 
-.type FSubInstruction = Instruction
+.type FSubInstruction <: symbol
 .decl fsub_instr(instr:FSubInstruction)
 
 instr(v) :- fsub_instr(v).

--- a/datalog/schema/getelementptr-instr.dl
+++ b/datalog/schema/getelementptr-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#getelementptr-instr
 // keywords: memory; instr
 
-.type GetElementPtrInstruction = Instruction
+.type GetElementPtrInstruction <: symbol
 .decl getelementptr_instr(instr:GetElementPtrInstruction)
 
 instr(v) :- getelementptr_instr(v).

--- a/datalog/schema/icmp-instr.dl
+++ b/datalog/schema/icmp-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#icmp-instr
 // keywords: comparison; binary; instr
 
-.type ICmpInstruction = Instruction
+.type ICmpInstruction <: symbol
 .decl icmp_instr(instr:ICmpInstruction)
 
 instr(v) :- icmp_instr(v).

--- a/datalog/schema/indirectbr-instr.dl
+++ b/datalog/schema/indirectbr-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#indirectbr-instr
 // keywords: terminator; instr
 
-.type IndirectBrInstruction = Instruction
+.type IndirectBrInstruction <: symbol
 .decl indirectbr_instr(instr:IndirectBrInstruction)
 
 instr(v) :- indirectbr_instr(v).

--- a/datalog/schema/insertelement-instr.dl
+++ b/datalog/schema/insertelement-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#insertelement-instr
 // keywords: vector; instr
 
-.type InsertElementInstruction = Instruction
+.type InsertElementInstruction <: symbol
 .decl insertelement_instr(instr:InsertElementInstruction)
 
 instr(v) :- insertelement_instr(v).

--- a/datalog/schema/insertvalue-instr.dl
+++ b/datalog/schema/insertvalue-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#insertvalue-instr
 // keywords: aggregate; instr
 
-.type InsertValueInstruction = Instruction
+.type InsertValueInstruction <: symbol
 .decl insertvalue_instr(instr:InsertValueInstruction)
 
 instr(v) :- insertvalue_instr(v).

--- a/datalog/schema/instr.dl
+++ b/datalog/schema/instr.dl
@@ -2,7 +2,70 @@
 // Instruction (EDB) Entities
 //------------------------------------
 
-.type Instruction <: symbol
+.type Instruction
+  = AShrInstruction
+  | AddInstruction
+  | AllocaInstruction
+  | AndInstruction
+  | AtomicRMWInstruction
+  | BitcastInstruction
+  | BrCondInstruction
+  | BrUncondInstruction
+  | CallInstruction
+  | CmpXchgInstruction
+  | ExtractElementInstruction
+  | ExtractValueInstruction
+  | FAddInstruction
+  | FCmpInstruction
+  | FDivInstruction
+  | FMulInstruction
+  | FPExtInstruction
+  | FPToSIInstruction
+  | FPToUIInstruction
+  | FPTruncInstruction
+  | FRemInstruction
+  | FSubInstruction
+  | FenceInstruction
+  | GetElementPtrInstruction
+  | ICmpInstruction
+  | IndirectBrInstruction
+  | InsertElementInstruction
+  | InsertValueInstruction
+  | IntToPtrInstruction
+  | InvokeInstruction
+  | LShrInstruction
+  | LandingPadInstruction
+  | LoadInstruction
+  | MulInstruction
+  | OrInstruction
+  | PhiInstruction
+  | PtrToIntInstruction
+  | ResumeInstruction
+  | RetInstruction
+  | SDivInstruction
+  | SExtInstruction
+  | SIToFPInstruction
+  | SRemInstruction
+  | SelectInstruction
+  | ShlInstruction
+  | ShuffleVectorInstruction
+  | StoreInstruction
+  | SubInstruction
+  | SwitchInstruction
+  | TruncInstruction
+  | UDivInstruction
+  | UIToFPInstruction
+  | URemInstruction
+  | UnreachableInstruction
+  | VaArgInstruction
+  | XorInstruction
+  | ZExtInstruction
+
+// Like llvm::CallBase
+.type CallBase
+  = CallInstruction
+  | InvokeInstruction
+
 .decl instr(instr:Instruction)
 
 // For constraints

--- a/datalog/schema/inttoptr-instr.dl
+++ b/datalog/schema/inttoptr-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#inttoptr-to-instr
 // keywords: conversion; unary; instr
 
-.type IntToPtrInstruction = Instruction
+.type IntToPtrInstruction <: symbol
 .decl inttoptr_instr(instr:IntToPtrInstruction)
 
 instr(v) :- inttoptr_instr(v).

--- a/datalog/schema/invoke-instr.dl
+++ b/datalog/schema/invoke-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#invoke-instr
 // keywords: terminator; instr
 
-.type InvokeInstruction = Instruction
+.type InvokeInstruction <: symbol
 .decl invoke_instr(instr:InvokeInstruction)
 
 instr(v) :- invoke_instr(v).

--- a/datalog/schema/landingpad-instr.dl
+++ b/datalog/schema/landingpad-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#landingpad-instr
 // keywords: exception; instr
 
-.type LandingPadInstruction = Instruction
+.type LandingPadInstruction <: symbol
 .decl landingpad_instr(instr:LandingPadInstruction)
 .decl landingpad_instr_is_cleanup(instr:LandingPadInstruction)
 
@@ -135,8 +135,8 @@ clause(c) :- catch_clause(c) ; filter_clause(c).
 .decl landingpad_instr_clause(instr:LandingPadInstruction, i:number, clause:Clause)
 .decl landingpad_instr_nclauses(instr:LandingPadInstruction, total:number)
 
-.decl landingpad_instr_catch_clause(v0:Instruction, v1:number, v2:Constant)
-.decl landingpad_instr_filter_clause(v0:Instruction, v1:number, v2:Constant)
+.decl landingpad_instr_catch_clause(v0:LandingPadInstruction, v1:number, v2:Constant)
+.decl landingpad_instr_filter_clause(v0:LandingPadInstruction, v1:number, v2:Constant)
 
 catch_clause(v2), landingpad_instr_clause(v0, v1, v2) :-
    landingpad_instr_catch_clause(v0, v1, v2).

--- a/datalog/schema/load-instr.dl
+++ b/datalog/schema/load-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#load-instr
 // keywords: memory; instr
 
-.type LoadInstruction = Instruction
+.type LoadInstruction <: symbol
 .decl load_instr(instr:LoadInstruction)
 
 instr(v) :- load_instr(v).

--- a/datalog/schema/lshr-instr.dl
+++ b/datalog/schema/lshr-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#lshr-instr
 // keywords: bitwise; binary; instr
 
-.type LShrInstruction = Instruction
+.type LShrInstruction <: symbol
 .decl lshr_instr(instr:LShrInstruction)
 
 instr(v) :-

--- a/datalog/schema/mul-instr.dl
+++ b/datalog/schema/mul-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#mul-instr
 // keywords: arithmetic; binary; instr
 
-.type MulInstruction = Instruction
+.type MulInstruction <: symbol
 .decl mul_instr(instr:MulInstruction)
 
 instr(v) :- mul_instr(v).

--- a/datalog/schema/or-instr.dl
+++ b/datalog/schema/or-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#or-instr
 // keywords: bitwise; binary; instr
 
-.type OrInstruction = Instruction
+.type OrInstruction <: symbol
 .decl or_instr(instr:OrInstruction)
 
 instr(v) :-

--- a/datalog/schema/phi-instr.dl
+++ b/datalog/schema/phi-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#phi-instr
 // keywords: index; instr
 
-.type PhiInstruction = Instruction
+.type PhiInstruction <: symbol
 .decl phi_instr(instr:PhiInstruction)
 
 instr(v) :- phi_instr(v).

--- a/datalog/schema/ptrtoint-instr.dl
+++ b/datalog/schema/ptrtoint-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#ptrtoint-to-instr
 // keywords: conversion; unary; instr
 
-.type PtrToIntInstruction = Instruction
+.type PtrToIntInstruction <: symbol
 .decl ptrtoint_instr(instr:PtrToIntInstruction)
 
 instr(v) :- ptrtoint_instr(v).

--- a/datalog/schema/resume-instr.dl
+++ b/datalog/schema/resume-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#resume-instr
 // keywords: terminator; instr
 
-.type ResumeInstruction = Instruction
+.type ResumeInstruction <: symbol
 .decl resume_instr(instr:ResumeInstruction)
 
 instr(v) :- resume_instr(v).

--- a/datalog/schema/ret-instr.dl
+++ b/datalog/schema/ret-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#ret-instr
 // keywords: terminator; instr
 
-.type RetInstruction = Instruction
+.type RetInstruction <: symbol
 .decl ret_instr(instr:RetInstruction)
 
 instr(v) :- ret_instr(v).

--- a/datalog/schema/sdiv-instr.dl
+++ b/datalog/schema/sdiv-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#sdiv-instr
 // keywords: arithmetic; binary; instr
 
-.type SDivInstruction = Instruction
+.type SDivInstruction <: symbol
 .decl sdiv_instr(instr:SDivInstruction)
 
 instr(v) :- sdiv_instr(v).

--- a/datalog/schema/select-instr.dl
+++ b/datalog/schema/select-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#select-instr
 // keywords: instr
 
-.type SelectInstruction = Instruction
+.type SelectInstruction <: symbol
 .decl select_instr(instr:SelectInstruction)
 
 instr(v) :- select_instr(v).

--- a/datalog/schema/sext-instr.dl
+++ b/datalog/schema/sext-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#sext-to-instr
 // keywords: conversion; unary; instr
 
-.type SExtInstruction = Instruction
+.type SExtInstruction <: symbol
 .decl sext_instr(instr:SExtInstruction)
 
 instr(v) :- sext_instr(v).

--- a/datalog/schema/shl-instr.dl
+++ b/datalog/schema/shl-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#shl-instr
 // keywords: bitwise; binary; instr
 
-.type ShlInstruction = Instruction
+.type ShlInstruction <: symbol
 .decl shl_instr(instr:ShlInstruction)
 
 instr(v) :-

--- a/datalog/schema/shufflevector-instr.dl
+++ b/datalog/schema/shufflevector-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#shufflevector-instr
 // keywords: vector; instr
 
-.type ShuffleVectorInstruction = Instruction
+.type ShuffleVectorInstruction <: symbol
 .decl shufflevector_instr(instr:ShuffleVectorInstruction)
 
 instr(v) :- shufflevector_instr(v).

--- a/datalog/schema/sitofp-instr.dl
+++ b/datalog/schema/sitofp-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#sitofp-to-instr
 // keywords: conversion; unary; instr
 
-.type SIToFPInstruction = Instruction
+.type SIToFPInstruction <: symbol
 .decl sitofp_instr(instr:SIToFPInstruction)
 
 instr(v) :- sitofp_instr(v).

--- a/datalog/schema/srem-instr.dl
+++ b/datalog/schema/srem-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#srem-instr
 // keywords: arithmetic; binary; instr
 
-.type SRemInstruction = Instruction
+.type SRemInstruction <: symbol
 .decl srem_instr(instr:SRemInstruction)
 
 instr(v) :- srem_instr(v).

--- a/datalog/schema/store-instr.dl
+++ b/datalog/schema/store-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#store-instr
 // keywords: memory; instr
 
-.type StoreInstruction = Instruction
+.type StoreInstruction <: symbol
 .decl store_instr(instr:StoreInstruction)
 
 instr(v) :- store_instr(v).
@@ -36,7 +36,7 @@ store_instr_is_atomic(Instr) :-
 // Helper predicates
 
 .decl store_instr_address_ptr_type(instr:StoreInstruction, type:Type)
-.decl store_instr_value_type(instr:StoreInstruction, type:Type) 
+.decl store_instr_value_type(instr:StoreInstruction, type:Type)
 
 store_instr_address_ptr_type(Instr, PtrType) :-
    store_instr_address(Instr, PtrAddress),

--- a/datalog/schema/sub-instr.dl
+++ b/datalog/schema/sub-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#sub-instr
 // keywords: arithmetic; binary; instr
 
-.type SubInstruction = Instruction
+.type SubInstruction <: symbol
 .decl sub_instr(instr:SubInstruction)
 
 instr(v) :- sub_instr(v).

--- a/datalog/schema/switch-instr.dl
+++ b/datalog/schema/switch-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#switch-instr
 // keywords: terminator; instr
 
-.type SwitchInstruction = Instruction
+.type SwitchInstruction <: symbol
 .decl switch_instr(instr:SwitchInstruction)
 
 instr(v) :- switch_instr(v).

--- a/datalog/schema/trunc-instr.dl
+++ b/datalog/schema/trunc-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#trunc-to-instr
 // keywords: conversion; unary; instr
 
-.type TruncInstruction = Instruction
+.type TruncInstruction <: symbol
 .decl trunc_instr(instr:TruncInstruction)
 
 instr(v) :- trunc_instr(v).

--- a/datalog/schema/udiv-instr.dl
+++ b/datalog/schema/udiv-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#udiv-instr
 // keywords: arithmetic; binary; instr
 
-.type UDivInstruction = Instruction
+.type UDivInstruction <: symbol
 .decl udiv_instr(instr:UDivInstruction)
 
 instr(v) :- udiv_instr(v).

--- a/datalog/schema/uitofp-instr.dl
+++ b/datalog/schema/uitofp-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#uitofp-to-instr
 // keywords: conversion; unary; instr
 
-.type UIToFPInstruction = Instruction
+.type UIToFPInstruction <: symbol
 .decl uitofp_instr(instr:UIToFPInstruction)
 
 instr(v) :- uitofp_instr(v).

--- a/datalog/schema/unreachable-instr.dl
+++ b/datalog/schema/unreachable-instr.dl
@@ -1,7 +1,7 @@
 // llvm.org/docs/LangRef.html#unreachable-instr
 // keywords: terminator; instr
 
-.type UnreachableInstruction = Instruction
+.type UnreachableInstruction <: symbol
 .decl unreachable_instr(instr:UnreachableInstruction)
 
 instr(v) :- unreachable_instr(v).

--- a/datalog/schema/urem-instr.dl
+++ b/datalog/schema/urem-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#urem-instr
 // keywords: arithmetic; binary; instr
 
-.type URemInstruction = Instruction
+.type URemInstruction <: symbol
 .decl urem_instr(instr:URemInstruction)
 
 instr(v) :- urem_instr(v).

--- a/datalog/schema/va-arg-instr.dl
+++ b/datalog/schema/va-arg-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#va-arg-instr
 // keywords: unary; instr
 
-.type VaArgInstruction = Instruction
+.type VaArgInstruction <: symbol
 .decl va_arg_instr(instr:VaArgInstruction)
 
 instr(v) :- va_arg_instr(v).

--- a/datalog/schema/xor-instr.dl
+++ b/datalog/schema/xor-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#xor-instr
 // keywords: bitwise; binary; instr
 
-.type XorInstruction = Instruction
+.type XorInstruction <: symbol
 .decl xor_instr(instr:XorInstruction)
 
 instr(v) :-

--- a/datalog/schema/zext-instr.dl
+++ b/datalog/schema/zext-instr.dl
@@ -1,7 +1,7 @@
 // http://llvm.org/docs/LangRef.html#zext-to-instr
 // keywords: conversion; unary; instr
 
-.type ZExtInstruction = Instruction
+.type ZExtInstruction <: symbol
 .decl zext_instr(instr:ZExtInstruction)
 
 instr(v) :- zext_instr(v).


### PR DESCRIPTION
This improves type safety, see e.g., the bug in callgraph.dl. Fixes #49.