### PR TITLE
datalog: Use more specific types

### DIFF
--- a/datalog/context/interface.dl
+++ b/datalog/context/interface.dl
@@ -1,4 +1,4 @@
-.type ContextItem = Instruction | symbol
+.type ContextItem = CallBase | symbol
 
 //---------------------------------------------------------
 // The Context datatype
@@ -80,7 +80,7 @@ drop_last(?out, ?in),
   // implementation details, and should not be accessed outside the component.
   //----------------------------------------------------------------------------
 
-  .decl _reachable_call(?ctx: Context, ?instr: Instruction)
+  .decl _reachable_call(?ctx: Context, ?instr: CallBase)
   _reachable_call(?ctx, ?instr) :-
     (call_instr(?instr); invoke_instr(?instr)),
     instr_func(?instr, ?func),
@@ -93,7 +93,7 @@ drop_last(?out, ?in),
   // 1. The call site
   // 2. The current calling context
   .decl merge(?newCtx: Context,
-              ?callerInstr: Instruction,
+              ?callerInstr: CallBase,
               ?callerCtx: Context)
 
   // The case of a "dropped" context item, see drop.dl
@@ -156,14 +156,14 @@ drop_last(?out, ?in),
   // Assertions
   //---------------------------------------------------------
 
-  .decl count_context_items(?instr: Instruction, ?nContextItems: number)
+  .decl count_context_items(?instr: CallBase, ?nContextItems: number)
   count_context_items(?instr, ?nContextItems) :-
     (call_instr(?instr); invoke_instr(?instr)),
     !drop_context_by_invoc(?instr),
     !drop_context_item_by_invoc(?instr),
     ?nContextItems = count : context_item_by_invoc(?instr, _).
 
-  .decl count_contexts(?instr: Instruction, ?nContexts: number)
+  .decl count_contexts(?instr: CallBase, ?nContexts: number)
   count_contexts(?instr, ?nContexts) :-
     (call_instr(?instr); invoke_instr(?instr)),
     !drop_context_by_invoc(?instr),
@@ -171,13 +171,13 @@ drop_last(?out, ?in),
     // Have to access internal relation due to inlining
     ?nContexts = count : merge(_, ?instr, _).
 
-  .decl assert_reachable_calls_have_context_items(?instr: Instruction)
+  .decl assert_reachable_calls_have_context_items(?instr: CallBase)
   assert_reachable_calls_have_context_items(?instr) :-
     user_options("context_sensitivity", _),
     _reachable_call(_, ?instr),
     count_context_items(?instr, 0).
 
-  .decl assert_reachable_calls_have_contexts(?instr: Instruction)
+  .decl assert_reachable_calls_have_contexts(?instr: CallBase)
   assert_reachable_calls_have_contexts(?instr) :-
     user_options("context_sensitivity", _),
     _reachable_call(_, ?instr),
@@ -232,8 +232,8 @@ context(?ctx),
 // Context sensitivity
 //---------------------------------------------------------
 
-.decl context_item_by_invoc(?invoc : Instruction, ?ctxItem : ContextItem)
-.decl context_item_by_invoc_interim(?invoc : Instruction, ?ctxItem : ContextItem)
+.decl context_item_by_invoc(?invoc : CallBase, ?ctxItem : ContextItem)
+.decl context_item_by_invoc_interim(?invoc : CallBase, ?ctxItem : ContextItem)
 
 context_item_by_invoc(?invoc, ?ctxItem) :-
   context_item_by_invoc_interim(?invoc, ?ctxItem),

--- a/datalog/points-to/at-exit.dl
+++ b/datalog/points-to/at-exit.dl
@@ -40,7 +40,7 @@ cxx_atexit_func(?func) :-
   //----------------------------------------------------------------------------
 
   .decl alloc_aliases(?alloc1: Allocation, ?alloc2: Allocation) inline
-  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction) inline
+  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase) inline
   .decl operand_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?operand: Operand) inline
   .decl reachable_context(?ctx: Context, ?func: FunctionDecl) inline
 

--- a/datalog/points-to/cplusplus-exceptions.dl
+++ b/datalog/points-to/cplusplus-exceptions.dl
@@ -167,7 +167,7 @@ typeinfo(?var),
   //----------------------------------------------------------------------------
 
   .decl allocation_type(?alloc:Allocation, ?type:Type) inline
-  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction) inline
+  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase) inline
   .decl operand_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?operand: Operand) inline
   .decl stripctx_operand_points_to(?alloc: Allocation, ?operand: Operand) inline
   .decl untyped_allocation(?insn: Instruction, ?alloc: Allocation) inline

--- a/datalog/points-to/cplusplus-exceptions.dl
+++ b/datalog/points-to/cplusplus-exceptions.dl
@@ -62,7 +62,7 @@ sized_alloc_instr(?insn, as(?size, Bytes)) :-
   // implementation details, and should not be accessed outside the component.
   //----------------------------------------------------------------------------
 
-  .decl untyped_allocation(?insn: Instruction, ?alloc: Allocation)
+  .decl untyped_allocation(?insn: AllocInstruction, ?alloc: Allocation)
 
   .decl _exception_object(?alloc: ExceptionObject)
 
@@ -71,7 +71,7 @@ sized_alloc_instr(?insn, as(?size, Bytes)) :-
 
   // Introduce new heap allocation selector
 
-  .decl heap_allocation_by_alloc_exc(?insn: Instruction, ?heapAlloc: HeapAllocation)
+  .decl heap_allocation_by_alloc_exc(?insn: CallBase, ?heapAlloc: HeapAllocation)
 
   heap_allocation_by_alloc_exc(?insn, ?heapAlloc)
   , _exception_object(?heapAlloc)
@@ -170,7 +170,7 @@ typeinfo(?var),
   .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase) inline
   .decl operand_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?operand: Operand) inline
   .decl stripctx_operand_points_to(?alloc: Allocation, ?operand: Operand) inline
-  .decl untyped_allocation(?insn: Instruction, ?alloc: Allocation) inline
+  .decl untyped_allocation(?insn: AllocInstruction, ?alloc: Allocation) inline
 
   //----------------------------------------------------------------------------
   // "Output"/defined rules
@@ -179,18 +179,18 @@ typeinfo(?var),
   // implementation details, and should not be accessed outside the component.
   //----------------------------------------------------------------------------
 
-  .decl _cxx_throw_instr(?throwInsn: Instruction)
+  .decl _cxx_throw_instr(?throwInsn: CallBase)
   _cxx_throw_instr(?throwInsn) :-
     cxx_throw_func(?throwFunc),
     callgraph_edge(_, ?throwFunc, _, ?throwInsn).
 
-  .decl _cxx_throw_instr_exception(?excObj: ExceptionObject, ?throwInsn: Instruction)
+  .decl _cxx_throw_instr_exception(?excObj: ExceptionObject, ?throwInsn: CallBase)
   _cxx_throw_instr_exception(?excObj, ?throwInsn) :-
     _cxx_throw_instr(?throwInsn),
     actual_arg(?throwInsn, 0, ?exc),
     operand_points_to(_, ?excObj, _, ?exc).
 
-  .decl _cxx_throw_instr_full_exception(?aCtx: Context, ?excObj: ExceptionObject, ?throwInsn: Instruction)
+  .decl _cxx_throw_instr_full_exception(?aCtx: Context, ?excObj: ExceptionObject, ?throwInsn: CallBase)
   _cxx_throw_instr_full_exception(?aCtx, ?excObj, ?throwInsn) :-
     _cxx_throw_instr(?throwInsn),
     actual_arg(?throwInsn, 0, ?exc),
@@ -200,14 +200,14 @@ typeinfo(?var),
   // * Throw Instr registers destructor
   //------------------------------------------------
 
-  .decl _cxx_throw_instr_destructor(?dtor: FunctionDecl, ?throwInsn: Instruction)
+  .decl _cxx_throw_instr_destructor(?dtor: FunctionDecl, ?throwInsn: CallBase)
   _cxx_throw_instr_destructor(?dtor, ?throwInsn) :-
     _cxx_throw_instr(?throwInsn),
     actual_arg(?throwInsn, 2, ?dtorArg),
     stripctx_operand_points_to(?alloc, ?dtorArg),
     func_by_location(?alloc, ?dtor).
 
-  .decl _cxx_throw_instr_no_dtor(?throwInsn: Instruction)
+  .decl _cxx_throw_instr_no_dtor(?throwInsn: CallBase)
   _cxx_throw_instr_no_dtor(?throwInsn) :-
     null_location(?null),
     _cxx_throw_instr(?throwInsn),
@@ -218,7 +218,7 @@ typeinfo(?var),
   // * Throw Instr associates typeinfo object
   //------------------------------------------------
 
-  .decl _cxx_throw_instr_typeinfo(?excTypeInfo: GlobalVariable, ?throwInsn: Instruction)
+  .decl _cxx_throw_instr_typeinfo(?excTypeInfo: GlobalVariable, ?throwInsn: CallBase)
   _cxx_throw_instr_typeinfo(?excTypeInfo, ?throwInsn) :-
     _cxx_throw_instr(?throwInsn),
     actual_arg(?throwInsn, 1, ?typeInfoArg),
@@ -269,7 +269,7 @@ typeinfo(?var),
     typeinfo(?typeInfo),
     !class_type_typeinfo(_, ?typeInfo).
 
-  .decl _cxx_throws(?dtor: FunctionDecl, ?typeInfo: GlobalVariable, ?excObj: ExceptionObject, ?throwInsn: Instruction)
+  .decl _cxx_throws(?dtor: FunctionDecl, ?typeInfo: GlobalVariable, ?excObj: ExceptionObject, ?throwInsn: CallBase)
   _cxx_throws(?dtor, ?typeInfo, ?excObj, ?throwInsn)
     :-
     _cxx_throw_instr_exception(?excObj, ?throwInsn),
@@ -288,7 +288,7 @@ typeinfo(?var),
     allocation_type(?excObj, ?type),
     class_type_destructor(?dtor, ?type).
 
-  .decl _cxx_throws_no_dtor(?typeInfo: GlobalVariable, ?excObj: ExceptionObject, ?throwInsn: Instruction)
+  .decl _cxx_throws_no_dtor(?typeInfo: GlobalVariable, ?excObj: ExceptionObject, ?throwInsn: CallBase)
   _cxx_throws_no_dtor(?typeInfo, ?excObj, ?throwInsn)
     :-
     _cxx_throw_instr_exception(?excObj, ?throwInsn),

--- a/datalog/points-to/cplusplus.dl
+++ b/datalog/points-to/cplusplus.dl
@@ -19,7 +19,7 @@ cxx_new_func(?func),
    !func_decl_to_defn(?func, _).
 
 // Introduce new heap allocation selector
-.decl heap_allocation_by_new(?insn: Instruction, ?heapAlloc: HeapAllocation)
+.decl heap_allocation_by_new(?insn: CallBase, ?heapAlloc: HeapAllocation)
 
 heap_allocation_by_new(?insn, ?heapAlloc) :-
    cxx_new_func(?func),
@@ -86,7 +86,7 @@ sized_alloc_instr(?insn, as(?size, Bytes)) :-
   // In the case of inlined constructors, we mark the heap allocation as
   // untyped and rely on the type back-propagation technique.
 
-  .decl untyped_allocation(?insn: Instruction, ?alloc: Allocation)
+  .decl untyped_allocation(?insn: CallBase, ?alloc: Allocation)
   untyped_allocation(?insn, ?heapAlloc) :-
     inlined_constructors(),
     heap_allocation_by_new(?insn, ?heapAlloc).

--- a/datalog/points-to/interprocedural.dl
+++ b/datalog/points-to/interprocedural.dl
@@ -17,7 +17,7 @@ func_by_location(?alloc, ?callee) :-
   .decl called_at_exit(func: FunctionDecl) inline
   .decl func_pointer_operand_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?operand: Operand) inline
 
-  .decl merge(?newCtx: Context, ?callerInstr: Instruction, ?callerCtx: Context)
+  .decl merge(?newCtx: Context, ?callerInstr: CallBase, ?callerCtx: Context)
 
   //----------------------------------------------------------------------------
   // "Output"/defined rules
@@ -80,11 +80,11 @@ func_by_location(?alloc, ?callee) :-
 
   // Callgraph
 
-  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction)
+  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase)
 
   // Direct func calls
 
-  .decl _callgraph_edge_interim_direct_call(?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction)
+  .decl _callgraph_edge_interim_direct_call(?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase)
 
   _callgraph_edge_interim_direct_call(?callee, ?callerCtx, ?callerInstr)
    :-
@@ -99,7 +99,7 @@ func_by_location(?alloc, ?callee) :-
      _callgraph_edge_interim_direct_call(?callee, ?callerCtx, ?callerInstr),
      merge(?calleeCtx, ?callerInstr, ?callerCtx).
 
-  .decl _callgraph_edge_interim_direct_invoke(?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction)
+  .decl _callgraph_edge_interim_direct_invoke(?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase)
 
   _callgraph_edge_interim_direct_invoke(?callee, ?callerCtx, ?callerInstr)
    :-
@@ -117,7 +117,7 @@ func_by_location(?alloc, ?callee) :-
 
   // Indirect func calls (via func pointers)
 
-  .decl _callgraph_edge_interim_indirect_call(?callee: FunctionDecl, ?callerCtx: Context, ?aCtx: Context, ?callerInstr: Instruction)
+  .decl _callgraph_edge_interim_indirect_call(?callee: FunctionDecl, ?callerCtx: Context, ?aCtx: Context, ?callerInstr: CallBase)
 
   _callgraph_edge_interim_indirect_call(?callee, ?callerCtx, ?aCtx, ?callerInstr)
    :-
@@ -136,7 +136,7 @@ func_by_location(?alloc, ?callee) :-
      _callgraph_edge_interim_indirect_call(?callee, ?callerCtx, _, ?callerInstr),
      merge(?calleeCtx, ?callerInstr, ?callerCtx).
 
-  .decl _callgraph_edge_interim_indirect_invoke(?callee: FunctionDecl, ?callerCtx: Context, ?aCtx: Context, ?callerInstr: Instruction)
+  .decl _callgraph_edge_interim_indirect_invoke(?callee: FunctionDecl, ?callerCtx: Context, ?aCtx: Context, ?callerInstr: CallBase)
 
   // TODO(lb): Perhaps don't store the allocation context? Seems unused by
   // callgraph_edge.
@@ -164,6 +164,7 @@ func_by_location(?alloc, ?callee) :-
 
 // Actual argument of func call
 
+// TODO(lb): This Instruction should be CallBase
 .decl actual_arg(?instr: Instruction, ?index: ArgumentIndex, ?argument: Operand)
 
 actual_arg(?invokeInstr, ?index, ?argument) :-
@@ -192,7 +193,7 @@ func_returns_value(?retValue, ?inFunction) :-
   // https://souffle-lang.github.io/components#input-rules
   //----------------------------------------------------------------------------
 
-  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction) inline
+  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase) inline
 
   //----------------------------------------------------------------------------
   // "Output"/defined rules

--- a/datalog/points-to/interprocedural.dl
+++ b/datalog/points-to/interprocedural.dl
@@ -164,8 +164,7 @@ func_by_location(?alloc, ?callee) :-
 
 // Actual argument of func call
 
-// TODO(lb): This Instruction should be CallBase
-.decl actual_arg(?instr: Instruction, ?index: ArgumentIndex, ?argument: Operand)
+.decl actual_arg(?instr: CallBase, ?index: ArgumentIndex, ?argument: Operand)
 
 actual_arg(?invokeInstr, ?index, ?argument) :-
   invoke_instr_arg(?invokeInstr, ?index, ?argument).

--- a/datalog/points-to/memcpy.dl
+++ b/datalog/points-to/memcpy.dl
@@ -17,7 +17,7 @@
   .decl alloc_subregion_at_any_array_index(?alloc: Allocation, ?region: AllocSubregion) inline
   .decl alloc_subregion_offset(?alloc: Allocation, ?region: AllocSubregion, ?offset: SubregionOffset) inline
   .decl allocation_type(?alloc:Allocation, ?type:Type) inline
-  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction) inline
+  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase) inline
   .decl memcpy_sig(?toCtx: Context, ?to: Allocation, ?fromCtx: Context , ?from: Allocation) inline
   .decl operand_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?operand: Operand) inline
   .decl var_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?var: Variable) inline

--- a/datalog/points-to/signatures.dl
+++ b/datalog/points-to/signatures.dl
@@ -113,7 +113,7 @@ build_signature_allocation_once(sigAlloc, func, type, pos) :-
   .decl allocation_type(?alloc:Allocation, ?type:Type) inline
   .decl alloc_may_alias(?alloc1: Allocation, ?alloc2: Allocation) inline
   .decl alloc_with_ctx(?aCtx: Context, ?alloc: Allocation) inline
-  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction) inline
+  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase) inline
   .decl reachable_context(?ctx: Context, ?func: FunctionDecl) inline
   .decl operand_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?operand: Operand) inline
   .decl ptr_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?ptr: Allocation) inline

--- a/datalog/points-to/strip-context-projections.dl
+++ b/datalog/points-to/strip-context-projections.dl
@@ -9,7 +9,7 @@
   // https://souffle-lang.github.io/components#input-rules
   //----------------------------------------------------------------------------
 
-  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: Instruction) inline
+  .decl callgraph_edge(?calleeCtx: Context, ?callee: FunctionDecl, ?callerCtx: Context, ?callerInstr: CallBase) inline
   .decl operand_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?operand: Operand) inline
   .decl ptr_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?ptr: Allocation) inline
   .decl var_points_to(?aCtx: Context, ?alloc: Allocation, ?ctx: Context, ?var: Variable) inline


### PR DESCRIPTION
They're more meaningful to readers of the code, and help improve type safety.