### PR TITLE
ci, cmake: Run clang-tidy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,32 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install linting tools
+    - name: Build dev image
       run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-format mypy
+        ./scripts/gha-docker-build "dev" "cclyzerpp-dev"
 
-    - name: Run linting script
-      run: bash scripts/lint.sh
+    - name: Lint
+      run: |
+        # See comment above
+        if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+          ref="${ACTUAL_GITHUB_SHA_ON_PULL_REQUEST}"
+        else
+          ref="${GITHUB_SHA}"
+        fi
+
+        docker run \
+          --rm \
+          --mount type=bind,src=$PWD,target=/work \
+          --workdir /work \
+          "ghcr.io/galoisinc/cclyzerpp-dev:${ref}" \
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -G Ninja -S . -B build
+
+        docker run \
+          --rm \
+          --mount type=bind,src=$PWD,target=/work \
+          --workdir /work \
+          "ghcr.io/galoisinc/cclyzerpp-dev:${ref}" \
+          bash scripts/lint.sh
 
   release:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ project(cclyzer++ LANGUAGES C CXX VERSION 0.3)
 
 # -----------------------------------------------------------------------------
 
-find_package(LLVM 10.0 REQUIRED CONFIG)
+set(LLVM_VER 10)
+find_package(LLVM ${LLVM_VER}.0 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
@@ -117,21 +118,6 @@ foreach(spa_source ${SPA_SOURCES})
   endif()
 endforeach()
 
-if(CLANG_TIDY)
-  add_custom_target(
-    spa-tidy
-    COMMAND ${CLANG_TIDY} -fix -p=${CMAKE_BINARY_DIR} -quiet
-            ${ABSOLUTE_SPA_SOURCES}
-    COMMENT "Linting with clang-tidy...")
-endif()
-
-if(CLANG_FORMAT)
-  add_custom_target(
-    spa-format
-    COMMAND ${CLANG_FORMAT} -i ${ABSOLUTE_SPA_SOURCES}
-    COMMENT "Formatting with clang-format...")
-endif()
-
 add_library(PAPassInterface INTERFACE)
 
 target_sources(PAPassInterface
@@ -218,16 +204,14 @@ endforeach()
 
 # -----------------------------------------------------------------------------
 
-# Add clang-tidy target
 find_program(
   CLANG_TIDY
-  NAMES "clang-tidy"
+  NAMES "clang-tidy" "clang-tidy-${LLVM_VER}"
   DOC "Path to clang-tidy executable.")
 
-# Add clang-format target
 find_program(
   CLANG_FORMAT
-  NAMES "clang-format"
+  NAMES "clang-format" "clang-format-${LLVM_VER}"
   DOC "Path to clang-format executable.")
 
 if(CLANG_TIDY)
@@ -236,6 +220,21 @@ if(CLANG_TIDY)
     COMMAND ${CLANG_TIDY} -fix -p=${CMAKE_BINARY_DIR} -quiet
             ${ABSOLUTE_FACTGEN_SOURCES}
     COMMENT "Linting with clang-tidy...")
+endif()
+
+if(CLANG_TIDY)
+  add_custom_target(
+    spa-tidy
+    COMMAND ${CLANG_TIDY} -fix -p=${CMAKE_BINARY_DIR} -quiet
+            ${ABSOLUTE_SPA_SOURCES}
+    COMMENT "Linting with clang-tidy...")
+endif()
+
+if(CLANG_FORMAT)
+  add_custom_target(
+    spa-format
+    COMMAND ${CLANG_FORMAT} -i ${ABSOLUTE_SPA_SOURCES}
+    COMMENT "Formatting with clang-format...")
 endif()
 
 # -----------------------------------------------------------------------------

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,6 +6,13 @@ for f in ./src/*.cpp ./FactGenerator/**/*.cpp; do
   clang-format-10 "${f}" | diff "${f}" -
 done
 
+if ! [[ -f build/compile_commands.json ]]; then
+  printf "Run cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -G Ninja -S . -B build.\n"
+  exit 1
+fi
+
+cmake --build build -j "$(nproc)" --target factgen-tidy
+
 cd test
 mypy .
 mypy ../scripts/*.py


### PR DESCRIPTION
Towards #32. Doesn't yet run on the C++ interface/LLVM pass, there's something wrong with the `spa-tidy` target.