### PR TITLE
Globals with initializers should have allocation sizes

### DIFF
--- a/test/c/allocation-sizes.c
+++ b/test/c/allocation-sizes.c
@@ -7,9 +7,9 @@
 #define LARGE_CONST_SIZE 128
 #define SMALL_CONST_SIZE 8
 
-int small_const_size_global[SMALL_CONST_SIZE];
-int large_const_size_global[LARGE_CONST_SIZE];
-int *dynamic_size_global;
+int small_const_size_global[SMALL_CONST_SIZE] = {0};
+int large_const_size_global[LARGE_CONST_SIZE] = {0};
+int *dynamic_size_global = {0};
 
 void set(int *, int) __attribute__((noinline));
 void set(int *buf, int sz) {

--- a/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O0-fno-discard-value-names.1-callsite.allocation_size.golden.csv
+++ b/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O0-fno-discard-value-names.1-callsite.allocation_size.golden.csv
@@ -7,15 +7,12 @@
 *global_alloc@.str[*][*]	1
 *global_alloc@.str[0]	13
 *global_alloc@.str[0][*]	1
-*global_alloc@dynamic_size_global	8
 *global_alloc@dynamic_size_global[*]	8
 *global_alloc@dynamic_size_global[0]	8
-*global_alloc@large_const_size_global	512
 *global_alloc@large_const_size_global[*]	512
 *global_alloc@large_const_size_global[*][*]	4
 *global_alloc@large_const_size_global[0]	512
 *global_alloc@large_const_size_global[0][*]	4
-*global_alloc@small_const_size_global	32
 *global_alloc@small_const_size_global[*]	32
 *global_alloc@small_const_size_global[*][*]	4
 *global_alloc@small_const_size_global[0]	32

--- a/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O0-fno-discard-value-names.2-callsite.allocation_size.golden.csv
+++ b/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O0-fno-discard-value-names.2-callsite.allocation_size.golden.csv
@@ -7,15 +7,12 @@
 *global_alloc@.str[*][*]	1
 *global_alloc@.str[0]	13
 *global_alloc@.str[0][*]	1
-*global_alloc@dynamic_size_global	8
 *global_alloc@dynamic_size_global[*]	8
 *global_alloc@dynamic_size_global[0]	8
-*global_alloc@large_const_size_global	512
 *global_alloc@large_const_size_global[*]	512
 *global_alloc@large_const_size_global[*][*]	4
 *global_alloc@large_const_size_global[0]	512
 *global_alloc@large_const_size_global[0][*]	4
-*global_alloc@small_const_size_global	32
 *global_alloc@small_const_size_global[*]	32
 *global_alloc@small_const_size_global[*][*]	4
 *global_alloc@small_const_size_global[0]	32

--- a/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O1-fno-discard-value-names.1-callsite.allocation_size.golden.csv
+++ b/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O1-fno-discard-value-names.1-callsite.allocation_size.golden.csv
@@ -7,15 +7,12 @@
 *global_alloc@.str[*][*]	1
 *global_alloc@.str[0]	13
 *global_alloc@.str[0][*]	1
-*global_alloc@dynamic_size_global	8
 *global_alloc@dynamic_size_global[*]	8
 *global_alloc@dynamic_size_global[0]	8
-*global_alloc@large_const_size_global	512
 *global_alloc@large_const_size_global[*]	512
 *global_alloc@large_const_size_global[*][*]	4
 *global_alloc@large_const_size_global[0]	512
 *global_alloc@large_const_size_global[0][*]	4
-*global_alloc@small_const_size_global	32
 *global_alloc@small_const_size_global[*]	32
 *global_alloc@small_const_size_global[*][*]	4
 *global_alloc@small_const_size_global[0]	32

--- a/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O1-fno-discard-value-names.2-callsite.allocation_size.golden.csv
+++ b/test/gold/allocation-sizes.clang.-g-grecord-gcc-switches-O1-O1-fno-discard-value-names.2-callsite.allocation_size.golden.csv
@@ -7,15 +7,12 @@
 *global_alloc@.str[*][*]	1
 *global_alloc@.str[0]	13
 *global_alloc@.str[0][*]	1
-*global_alloc@dynamic_size_global	8
 *global_alloc@dynamic_size_global[*]	8
 *global_alloc@dynamic_size_global[0]	8
-*global_alloc@large_const_size_global	512
 *global_alloc@large_const_size_global[*]	512
 *global_alloc@large_const_size_global[*][*]	4
 *global_alloc@large_const_size_global[0]	512
 *global_alloc@large_const_size_global[0][*]	4
-*global_alloc@small_const_size_global	32
 *global_alloc@small_const_size_global[*]	32
 *global_alloc@small_const_size_global[*][*]	4
 *global_alloc@small_const_size_global[0]	32


### PR DESCRIPTION
The first commit demonstrates a bug: These globals should have known size, but they don't. See discussion on https://github.com/GaloisInc/cclyzerpp/pull/93.