### PR TITLE
doc: Separate build, installation, and usage docs

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -17,7 +17,7 @@ information, rather just outputs a table-based view of the module's AST.
 
 The fact generator is also used to configure the analysis parameters, namely the
 type and amount of context sensitivity and points-to signatures. See the
-:ref:`documentation on configuring the analysis <configuration>` for more
+:ref:`documentation on using the analysis <configuration>` for more
 details.
 
 .. _cpp:

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -1,9 +1,13 @@
-Building and Running
-====================
+Building
+========
 
 .. note::
 
-  Pre-built Debian packages are available from the `releases page`_.
+  Most users don't need to build cclyzer++ from source: Pre-built Debian
+  packages and Docker images are available. See :doc:`install` for more details.
+
+Build Dependencies
+******************
 
 .. note::
 
@@ -20,6 +24,11 @@ Ubuntu 20.04:
 
     apt-get install libboost-system-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev
 
+Configuring the Build
+*********************
+
+You can pass ``-DLLVM_MAJOR_VERSION=10`` to CMake to build against LLVM 10.
+
 Building the Fact Generator
 ***************************
 
@@ -30,106 +39,24 @@ To build the fact generator, run
   cmake -G Ninja -B build -S .
   cmake --build build -j $(nproc) --target factgen-exe
 
-You should now see an executable at ``build/factgen-exe``. See :ref:`the
-architecture documentation <architecture>` for more information on the role of
-the fact generator.
+You should now see an executable at ``build/factgen-exe``.
 
-.. _configuration:
+See :ref:`the architecture documentation <architecture>` for more information on
+the role of the fact generator, and :ref:`the usage documentation
+<configuration>` for details on running it.
 
-Configuring the Analysis
-************************
-
-The analysis is configured via command-line arguments passed to the fact
-generator, primarily ``--context-sensitivity`` and ``--signatures``. For
-example,
-
-.. code-block:: bash
-
-  factgen-exe --out-dir <fact-dir> --signatures sigs.json --context-sensitivity 1-callsite prog.bc
-
-where ``prog.bc`` is an LLVM bitcode module. The valid settings for context
-sensitivity are:
-
-* ``insensitive``
-* ``1-callsite``
-* ``2-callsite``
-* ``3-callsite``
-* ``4-callsite``
-* ``5-callsite``
-* ``6-callsite``
-* ``7-callsite``
-* ``8-callsite``
-* ``9-callsite``
-* ``1-caller``
-* ``2-caller``
-* ``3-caller``
-* ``4-caller``
-* ``5-caller``
-* ``6-caller``
-* ``7-caller``
-* ``8-caller``
-* ``9-caller``
-* ``1-file``
-* ``2-file``
-* ``3-file``
-* ``4-file``
-* ``5-file``
-* ``6-file``
-* ``7-file``
-* ``8-file``
-* ``9-file``
-
-Run ``factgen-exe --help`` to see the full list of options.
-
-Running the Analysis
-********************
-
-Soufflé ships with an interpreter and a *synthesizer*, which outputs C++ code
-that can be compiled by Clang. Accordingly, there are three ways to run the
-analysis:
-
-* Directly via the Soufflé interpreter
-* By synthesizing the Datalog to C++ and then either
-  - compiling the C++ via Clang to a standalone executable
-  - compiling the C++ via Clang to a shared library that gets loaded by LLVM's ``opt`` and used by the C++ interface
-
-With Soufflé
-~~~~~~~~~~~~
-
-Here's how to run the subset analysis via the Soufflé interpreter:
-
-.. code-block:: bash
-
-  souffle --fact-dir <fact-dir> --output-dir <output-dir> datalog/subset.project
-
-where ``fact-dir`` was the directory passed to the ``--out-dir`` option of the
-fact generator. Pass ``-j <n>`` to parallelize the analysis across *n* threads.
-See `the Soufflé documentation <run-souffle>`_ for more details.
-
-To synthesize and compile the analysis, run
-
-.. code-block:: bash
-
-  souffle --generate=subset.cpp datalog/subset.project
-  souffle-compile.py subset.cpp
-  subset --facts <fact-dir> --output <output-dir> -j <n>
-
-.. _opt:
-
-With Opt
-~~~~~~~~
+Building the C++ Interface
+**************************
 
 To synthesize C++ code, compile it to a shared library, and compile the C++
-interface, install LLVM and run
+interface, run
 
 .. code-block:: bash
 
   cmake --build build -j $(nproc) --target PAPass
-  opt --disable-output --load=build/libSoufflePA.so --load=build/libPAPass.so -cclyzer --context-sensitivity=1-callsite --datalog-analysis=subset prog.bc
 
-(You could also run CMake without specifying ``--target PAPass``.) Run
-``opt --load=build/libSoufflePA.so --load=build/libPAPass.so --help`` to see
-more options - though many of them are irrelevant.
+(You could also run CMake without specifying ``--target PAPass``.) The pass can
+be run with ``opt``, see :ref:`the usage documentation <opt>`.
 
 .. _Soufflé build documentation: https://souffle-lang.github.io/build
 .. _releases page: https://github.com/GaloisInc/cclyzerpp/releases

--- a/doc/docker.rst
+++ b/doc/docker.rst
@@ -9,6 +9,8 @@ cclyzer++ ships with two dockerfiles in ``docker/``:
 Obtaining Images
 ****************
 
+.. _ghcr:
+
 Pulling from GHCR
 ~~~~~~~~~~~~~~~~~
 
@@ -19,6 +21,8 @@ You can pull pre-built images from GHCR like so:
   docker pull ghcr.io/galoisinc/cclyzerpp-dev:main
 
 Tags can be branch names or commit SHAs of releases.
+
+.. _docker-build:
 
 Building Locally
 ~~~~~~~~~~~~~~~~

--- a/doc/docker.rst
+++ b/doc/docker.rst
@@ -20,7 +20,14 @@ You can pull pre-built images from GHCR like so:
 
   docker pull ghcr.io/galoisinc/cclyzerpp-dev:main
 
-Tags can be branch names or commit SHAs of releases.
+The ``main`` tag refers to the most recent release. You can also specify a tag
+or commit SHA of a previous release, e.g.,
+
+.. code-block:: bash
+
+  # The following are equivalent:
+  docker pull ghcr.io/galoisinc/cclyzerpp-dev:v0.5.0
+  docker pull ghcr.io/galoisinc/cclyzerpp-dev:47bea4c4223d653209d28b932824618128f47910
 
 .. _docker-build:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,19 +39,26 @@ Table of Contents
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: User Documentation
 
    architecture
-   build
    changelog
    design
-   dev
    docker
    implementation
-   legal
+   install
    overview
    signatures
    unsoundness
+   usage
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Developer Documentation
+
+   build
+   dev
+   legal
 
 Indices and tables
 ------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,0 +1,11 @@
+Installation
+============
+
+Pre-built Debian packages are available from the `releases page`_.
+
+You can download Docker images from GHCR or them build yourself; see
+:doc:`docker`.
+
+If you need to use LLVM 10, you'll have to build from source. See :doc:`build`.
+
+.. _releases page: https://github.com/GaloisInc/cclyzerpp/releases

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -1,0 +1,114 @@
+Usage
+=====
+
+See :doc:`install` for how to install cclyzer++.
+
+.. _configuration:
+
+Configuring the Analysis
+************************
+
+The analysis is configured via command-line arguments passed to the fact
+generator, primarily ``--context-sensitivity`` and ``--signatures``. For
+example,
+
+.. code-block:: bash
+
+  factgen-exe --out-dir <fact-dir> --signatures sigs.json --context-sensitivity 1-callsite prog.bc
+
+where ``prog.bc`` is an LLVM bitcode module. The valid settings for context
+sensitivity are:
+
+* ``insensitive``
+* ``1-callsite``
+* ``2-callsite``
+* ``3-callsite``
+* ``4-callsite``
+* ``5-callsite``
+* ``6-callsite``
+* ``7-callsite``
+* ``8-callsite``
+* ``9-callsite``
+* ``1-caller``
+* ``2-caller``
+* ``3-caller``
+* ``4-caller``
+* ``5-caller``
+* ``6-caller``
+* ``7-caller``
+* ``8-caller``
+* ``9-caller``
+* ``1-file``
+* ``2-file``
+* ``3-file``
+* ``4-file``
+* ``5-file``
+* ``6-file``
+* ``7-file``
+* ``8-file``
+* ``9-file``
+
+Run ``factgen-exe --help`` to see the full list of options. See :ref:`the
+architecture documentation <architecture>` for more information on the role of
+the fact generator.
+
+Running the Analysis
+********************
+
+Soufflé ships with an interpreter and a *synthesizer*, which outputs C++ code
+that can be compiled by Clang. Accordingly, there are three ways to run the
+analysis:
+
+* Directly via the Soufflé interpreter
+* By synthesizing the Datalog to C++ and then either
+
+  - compiling the C++ via Clang to a standalone executable
+  - compiling the C++ via Clang to a shared library that gets loaded by LLVM's ``opt`` and used by the C++ interface
+
+The Debian package and ``dist`` Docker image only ship with the latter option.
+
+.. _opt:
+
+With Opt
+~~~~~~~~
+
+The LLVM pass is used via ``opt``. If you installed via the Debian package or
+are running in the ``dist`` container, try:
+
+.. code-block:: bash
+
+  opt --disable-output --load=/usr/lib/libSoufflePA.so --load=/usr/lib/libPAPass.so -cclyzer --context-sensitivity=1-callsite --datalog-analysis=subset prog.bc
+
+To see more options, run
+
+.. code-block:: bash
+
+  opt --load=/usr/lib/libSoufflePA.so --load=/usr/lib/libPAPass.so --help
+
+though be warned - this includes all ``opt`` flags, and most of them are
+irrelevant to running the analysis.
+
+(If you built from source, the ``.so`` files will be in ``build/``.)
+
+With Soufflé
+~~~~~~~~~~~~
+
+If you're not running in the ``dist`` Docker image and have the cclyzer++ source
+available, you can run the analysis from the Soufflé interpreter. For example,
+here's how to run the subset analysis:
+
+.. code-block:: bash
+
+  souffle --fact-dir <fact-dir> --output-dir <output-dir> datalog/subset.project
+
+where ``fact-dir`` was the directory passed to the ``--out-dir`` option of the
+fact generator. Pass ``-j <n>`` to parallelize the analysis across *n* threads.
+See `the Soufflé documentation <run-souffle>`_ for more details.
+
+To synthesize and compile the analysis, run
+
+.. code-block:: bash
+
+  souffle --generate=subset.cpp datalog/subset.project
+  souffle-compile.py subset.cpp
+  subset --facts <fact-dir> --output <output-dir> -j <n>


### PR DESCRIPTION
Also:

- Update Docker image docs
- Separate dev/user docs
- Document building with LLVM 10
- Prefer running with `opt`, as that's what's available with the release artifacts (Debian packages/Docker images)