### PR TITLE
schema: made constant_hashes_to hashcode unsigned

### DIFF
--- a/datalog/schema/operand.dl
+++ b/datalog/schema/operand.dl
@@ -50,7 +50,7 @@ variable_in_func(Variable, Function) :-
 .decl constant_has_value(c:Constant, val:symbol)
 
 // Precomputed hash-codes for constant values
-.decl constant_hashes_to(c:Constant, hashcode:number)
+.decl constant_hashes_to(c:Constant, hashcode:unsigned)
 
 // Previously derived. Now implemented as a macro
 #define constants_equal(X, Y)  \


### PR DESCRIPTION
I was getting an error when loading constant_hashes_to data with the number too large to fit into a signed integer. Changing to an unsigned integer fixed this