### PR TITLE
fact-gen: move is_itanium_encodingto Demangler

### DIFF
--- a/FactGenerator/include/Demangler.hpp
+++ b/FactGenerator/include/Demangler.hpp
@@ -8,7 +8,17 @@
 
 class Demangler {
  public:
-  inline auto demangle(const char* name) -> std::string {
+  /* NOTE(ww): Stolen from Demangle.cpp (not present in LLVM 7).
+   */
+  static inline auto is_itanium_encoding(const std::string& MangledName)
+      -> bool {
+    size_t pos = MangledName.find_first_not_of('_');
+    // A valid Itanium encoding requires 1-4 leading underscores, followed by
+    // 'Z'.
+    return pos > 0 && pos <= 4 && MangledName[pos] == 'Z';
+  }
+
+  static inline auto demangle(const char* name) -> std::string {
     int status = -1;
 
     std::unique_ptr<char, void (*)(void*)> res{
@@ -16,7 +26,7 @@ class Demangler {
     return (status == 0) ? res.get() : std::string(name);
   }
 
-  inline auto demangle(const std::string& name) -> std::string {
+  static inline auto demangle(const std::string& name) -> std::string {
     return demangle(name.c_str());
   }
 };

--- a/FactGenerator/src/FactGenerator.cpp
+++ b/FactGenerator/src/FactGenerator.cpp
@@ -23,15 +23,6 @@ auto FactGenerator::getInstance(FactWriter &writer) -> FactGenerator & {
   return this_instance;
 }
 
-/* NOTE(ww): Stolen from Demangle.cpp (not present in LLVM 7).
- */
-static inline auto is_itanium_encoding(const std::string &MangledName) -> bool {
-  size_t pos = MangledName.find_first_not_of('_');
-  // A valid Itanium encoding requires 1-4 leading underscores, followed by
-  // 'Z'.
-  return pos > 0 && pos <= 4 && MangledName[pos] == 'Z';
-}
-
 auto FactGenerator::processModule(
     const llvm::Module &Mod,
     const std::string &path,


### PR DESCRIPTION
Hey @langston-barrett! Just a tiny mode from me; moving `is_itanium_encoding` from the `FactGenerator` to the `Demangler`. I think this makes sense (as it's related to demangling) and means I can access the encoding check from outside the fact generator.

Cheers!!