### PR TITLE
fact-gen: make variable_in_func relation consistent wrt function names

### DIFF
--- a/FactGenerator/src/FactGenerator.cpp
+++ b/FactGenerator/src/FactGenerator.cpp
@@ -98,7 +98,7 @@ auto FactGenerator::processModule(
       // Record basic block entry as a label
       writeFact(pred::variable::id, bb_ref);
       writeFact(pred::variable::type, bb_ref, "label");
-      writeFact(pred::variable::in_func, bb_ref, func.getName().str());
+      writeFact(pred::variable::in_func, bb_ref, "@" + func.getName().str());
 
       // Record variable name part
       size_t idx = bb_ref.find_last_of("%!");


### PR DESCRIPTION
The `variable_in_func_name` and `constant_in_func_name` relations are inconsistent with how they deal with function names. For example, [here](https://github.com/GaloisInc/cclyzerpp/blob/main/FactGenerator/src/Variables.cpp#L20) and [here](https://github.com/GaloisInc/cclyzerpp/blob/main/FactGenerator/src/Constants.cpp#L34) the function name is prepended with an `@`. However, [here](https://github.com/GaloisInc/cclyzerpp/blob/main/FactGenerator/src/FactGenerator.cpp#L101) this **doesn't** happen.

I assume this is not intentional, as it appears to break the `func_name` relation.